### PR TITLE
DeprecationWarning: There is no current event loop, loop = asyncio.ge…

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,7 @@ async def main():
     cl = await spacex.capsules()
     print(cl)
 
-loop = asyncio.get_event_loop()
-loop.run_until_complete(main())
+asyncio.run(main())
 ```
 
 Print:


### PR DESCRIPTION
In the README.md the example is using a deprecated function as message displayed below:
```
DeprecationWarning: There is no current event loop
  loop = asyncio.get_event_loop()
```

Recommended to use: 
`asyncio.run(main())` 